### PR TITLE
Set the process name of the forked process

### DIFF
--- a/lib/daemonette.rb
+++ b/lib/daemonette.rb
@@ -36,7 +36,10 @@ class Daemonette
         raise e
       end
     }
-    Process.detach forked_pid if forked_pid
+    if forked_pid
+      Process.detach forked_pid
+      $0 = "#{$0} (DAEMONETTE: #{@name})"
+    end
   end
 
 private


### PR DESCRIPTION
This is so when we do `ps aux` we can easily see which background processes are running; at the moment they all just say `rake messenger:listen` in the process list.
